### PR TITLE
Add workflow to thank signatories and request sharing

### DIFF
--- a/.github/workflows/thank-signatory.yml
+++ b/.github/workflows/thank-signatory.yml
@@ -1,0 +1,48 @@
+name: Thank Signatory
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  thank:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'add-signatory/issue-')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Post thank-you comment on original issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = context.payload.pull_request.head.ref;
+            const match = branchName.match(/^add-signatory\/issue-(\d+)$/);
+            if (!match) {
+              core.setFailed(`Could not extract issue number from branch: ${branchName}`);
+              return;
+            }
+            const issueNumber = parseInt(match[1], 10);
+
+            const body = [
+              "Welcome, and thank you for signing the Use What Works manifesto!",
+              "",
+              "Your signature is now live on [usewhatworks.org](https://usewhatworks.org). You're part of a growing group of folks who believe in choosing proven solutions over reinventing the wheel.",
+              "",
+              "## Would you help spread the word?",
+              "",
+              "The manifesto only grows through people like you sharing it. If you'd like to help:",
+              "",
+              "1. **Post about it** on X, BlueSky, LinkedIn, Mastodon, or wherever you're active. A few sentences about why this resonates with you is enough. Link to <https://usewhatworks.org> so others can find it.",
+              "2. **Drop the link to your post back here as a comment.** Other signatories follow this thread, and when they see a post they appreciate, they can reshare it and help amplify your voice.",
+              "",
+              "That way, every new signature becomes a small boost for the ones that came before it.",
+              "",
+              "Thanks again for being part of this."
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: body
+            });

--- a/.github/workflows/thank-signatory.yml
+++ b/.github/workflows/thank-signatory.yml
@@ -32,7 +32,7 @@ jobs:
               "",
               "The manifesto only grows through people like you sharing it. If you'd like to help:",
               "",
-              "1. **Post about it** on X, BlueSky, LinkedIn, Mastodon, or wherever you're active. A few sentences about why this resonates with you is enough. Link to <https://usewhatworks.org> so others can find it.",
+              "1. **Post about it** on X, BlueSky, LinkedIn, Mastodon, or wherever you're active. A few sentences about why this resonates with you is enough. Use #usewhatworks so others can find it.",
               "2. **Drop the link to your post back here as a comment.** Other signatories follow this thread, and when they see a post they appreciate, they can reshare it and help amplify your voice.",
               "",
               "That way, every new signature becomes a small boost for the ones that came before it.",

--- a/.github/workflows/thank-signatory.yml
+++ b/.github/workflows/thank-signatory.yml
@@ -26,16 +26,13 @@ jobs:
             const body = [
               "Welcome, and thank you for signing the Use What Works manifesto!",
               "",
-              "Your signature is now live on [usewhatworks.org](https://usewhatworks.org). You're part of a growing group of folks who believe in choosing proven solutions over reinventing the wheel.",
+              "Your signature is now live on [usewhatworks.org](https://usewhatworks.org). You're part of a growing group of people helping the industry build on ever-more stable foundations.",
               "",
-              "## Would you help spread the word?",
+              "## Who else should get this message?",
               "",
-              "The manifesto only grows through people like you sharing it. If you'd like to help:",
-              "",
-              "1. **Post about it** on X, BlueSky, LinkedIn, Mastodon, or wherever you're active. A few sentences about why this resonates with you is enough. Use #usewhatworks so others can find it.",
-              "2. **Drop the link to your post back here as a comment.** Other signatories follow this thread, and when they see a post they appreciate, they can reshare it and help amplify your voice.",
-              "",
-              "That way, every new signature becomes a small boost for the ones that came before it.",
+              "Send them a link.",
+              "",              
+              "If it wouldn't be too much trouble, we'd really appreciate it if you could also post something on LinkedIn, BlueSky, Twitter/X, Mastodon, Reddit, or wherever you're active. Add the #UseWhatWorks hashtag so others can find it more easily.",              
               "",
               "Thanks again for being part of this."
             ].join("\n");


### PR DESCRIPTION
When a signature PR is merged, post a comment on the original issue asking the signatory to share on social media and drop the link back so other signatories can reshare.